### PR TITLE
Relax requirement of rest-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,27 +2,29 @@ PATH
   remote: .
   specs:
     xivapi (0.3.0)
-      rest-client (~> 2.0.2)
+      rest-client (>= 2.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    mime-types (3.2.2)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.1009)
     netrc (0.11.0)
     rake (10.4.2)
-    rest-client (2.0.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     yard (0.9.19)
 
 PLATFORMS
@@ -35,4 +37,4 @@ DEPENDENCIES
   yard (~> 0.9.19)
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     xivapi (0.3.0)
-      rest-client (>= 2.0.2)
+      rest-client (~> 2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/xivapi.gemspec
+++ b/xivapi.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "yard", "~> 0.9.19"
-  spec.add_dependency "rest-client", ">= 2.0.2"
+  spec.add_dependency "rest-client", "~> 2.0"
 end

--- a/xivapi.gemspec
+++ b/xivapi.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "yard", "~> 0.9.19"
-  spec.add_dependency "rest-client", "~> 2.0.2"
+  spec.add_dependency "rest-client", ">= 2.0.2"
 end


### PR DESCRIPTION
Installing this gem in an existing project failed due to a dependency resolution between the `~> 2.0.2` version of `rest-client` and other gems in the bundle. Since the newer versions of rest-client don't seem to have any breaking changes, I've relaxed the requirement to any higher version.

I've also regenerated the lockfile, which I'm not entirely sure is necessary here. ¯\\_(ツ)_/¯